### PR TITLE
Fix the edit menu button for non-root domain installs

### DIFF
--- a/classes/kiwiki_functions.php
+++ b/classes/kiwiki_functions.php
@@ -12,7 +12,7 @@ class Kiwiki_Functions {
             $editicon = (new \dokuwiki\Menu\KiwikiEdit())->getListItems('kiwiki-',true);
             
             if (!empty($what)){
-                $editicon = preg_replace('/<a(.*)href="([^"]*)"(.*)>/','<a$1href="/doku.php?id='.$what.'&do=edit"$3>',$editicon);
+                $editicon = preg_replace('/<a(.*)href="([^"]*)"(.*)>/','<a$1href="'.DOKU_BASE.'doku.php?id='.$what.'&do=edit"$3>',$editicon);
             }
             return $editicon;
         }


### PR DESCRIPTION
Hi!

I recently installed this template on my instance with DokuWiki installed at https://domain.tld/wiki and when I clicked the edit button for the main menu, it redirected me to:
`https://domain.tld/doku.php?id=mainmenu&do=edit`
rather than:
`https://domain.tld/wiki/doku.php?id=mainmenu&do=edit`

I added the [DOKU_BASE](https://www.dokuwiki.org/devel:environment#doku) string to the redirect link in the kiwiki_functions.php file to fix this. Haven't tested this on dokuwiki installed on the root of a domain but I'd imagine it'd work there too :)

Thanks for your work, really love the template!